### PR TITLE
Property what allow using Layout for Message in JSON format

### DIFF
--- a/src/NLog.Targets.RabbitMQ/MessageFormatter.cs
+++ b/src/NLog.Targets.RabbitMQ/MessageFormatter.cs
@@ -18,7 +18,12 @@ namespace NLog.Targets
 			get { return _hostName = (_hostName ?? Dns.GetHostName()); }
 		}
 
-		public static string GetMessageInner(bool useJSON, Layout layout, LogEventInfo info, IList<Field> fields)
+        public static string GetMessageInner(bool useJSON, Layout layout, LogEventInfo info, IList<Field> fields)
+        {
+            return GetMessageInner(useJSON, false, layout, info, fields);
+        }
+
+		public static string GetMessageInner(bool useJSON, bool useLayoutAsMessage, Layout layout, LogEventInfo info, IList<Field> fields)
 		{
 			if (!useJSON)
 				return layout.Render(info);
@@ -26,7 +31,7 @@ namespace NLog.Targets
 			var logLine = new LogLine
 				{
 					TimeStampISO8601 = info.TimeStamp.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture),
-					Message = info.FormattedMessage,
+					Message = useLayoutAsMessage ? layout.Render(info) : info.FormattedMessage,
 					Level = info.Level.Name,
 					Type = "amqp",
 					Source = new Uri(string.Format("nlog://{0}/{1}", HostName, info.LoggerName))

--- a/src/NLog.Targets.RabbitMQ/MessageFormatter.cs
+++ b/src/NLog.Targets.RabbitMQ/MessageFormatter.cs
@@ -18,10 +18,10 @@ namespace NLog.Targets
 			get { return _hostName = (_hostName ?? Dns.GetHostName()); }
 		}
 
-        public static string GetMessageInner(bool useJSON, Layout layout, LogEventInfo info, IList<Field> fields)
-        {
-            return GetMessageInner(useJSON, false, layout, info, fields);
-        }
+		public static string GetMessageInner(bool useJSON, Layout layout, LogEventInfo info, IList<Field> fields)
+		{
+			return GetMessageInner(useJSON, false, layout, info, fields);
+		}
 
 		public static string GetMessageInner(bool useJSON, bool useLayoutAsMessage, Layout layout, LogEventInfo info, IList<Field> fields)
 		{

--- a/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
+++ b/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
@@ -292,6 +292,12 @@ namespace NLog.Targets
 		[ArrayParameter(typeof(Field), "field")]
 		public IList<Field> Fields { get; private set; }
 
+        /// <summary>
+        /// Using for JSON formating (when UseJSON set true). 
+        /// If set as true - <see cref="NLog.Targets.LogLine.Message"/> field rendered by Layout prorerty instead getting <see cref="NLog.LogEventInfo.FormattedMessage"/>
+        /// </summary>
+        public bool UseLayoutAsMessage { get; set; }
+
 		#endregion
 
 		protected override void Write(AsyncLogEventInfo logEvent)
@@ -370,7 +376,7 @@ namespace NLog.Targets
 
 		private byte[] GetMessage(AsyncLogEventInfo info)
 		{
-			return _Encoding.GetBytes(MessageFormatter.GetMessageInner(_UseJSON, Layout, info.LogEvent, this.Fields));
+			return _Encoding.GetBytes(MessageFormatter.GetMessageInner(_UseJSON, this.UseLayoutAsMessage, Layout, info.LogEvent, this.Fields));
 		}
 
 		private IBasicProperties GetBasicProperties(AsyncLogEventInfo loggingEvent)

--- a/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
+++ b/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
@@ -292,11 +292,11 @@ namespace NLog.Targets
 		[ArrayParameter(typeof(Field), "field")]
 		public IList<Field> Fields { get; private set; }
 
-        /// <summary>
-        /// Using for JSON formating (when UseJSON set true). 
-        /// If set as true - <see cref="NLog.Targets.LogLine.Message"/> field rendered by Layout prorerty instead getting <see cref="NLog.LogEventInfo.FormattedMessage"/>
-        /// </summary>
-        public bool UseLayoutAsMessage { get; set; }
+		/// <summary>
+		/// Using for JSON formating (when UseJSON set true). 
+		/// If set as true - <see cref="NLog.Targets.LogLine.Message"/> field rendered by Layout prorerty instead getting <see cref="NLog.LogEventInfo.FormattedMessage"/>
+		/// </summary>
+		public bool UseLayoutAsMessage { get; set; }
 
 		#endregion
 

--- a/src/schemas/NLog.RabbitMQ.xsd
+++ b/src/schemas/NLog.RabbitMQ.xsd
@@ -31,7 +31,7 @@
 					<element name="maxBuffer" type="integer" minOccurs="0" maxOccurs="1" />
 					<element name="heartBeatSeconds" type="unsignedShort" minOccurs="0" maxOccurs="1" />
 					<element name="useJSON" type="boolean" minOccurs="0" maxOccurs="1" />
-          <element name="useLayoutAsMessage" type="boolean" minOccurs="0" maxOccurs="1" />
+					<element name="useLayoutAsMessage" type="boolean" minOccurs="0" maxOccurs="1" />
 					<element name="compression" type="string" minOccurs="0" maxOccurs="1" />
 					<element name="layout" type="nlog:Layout" minOccurs="0" maxOccurs="1" />
 					<element name="field" minOccurs="0" maxOccurs="unbounded">
@@ -107,20 +107,20 @@
 					</annotation>
 				</attribute>
 				<attribute name="useJSON" type="boolean" default="false">
-				 <annotation>
-					 <documentation>Whether to publish the message as a JSON structure (recommended!). If true then the defined layout will not be used.</documentation>
-				 </annotation>
+					<annotation>
+						<documentation>Whether to publish the message as a JSON structure (recommended!). If true then the defined layout will not be used.</documentation>
+					</annotation>
 				</attribute>
-        <attribute name="useLayoutAsMessage" type="boolean" default="false">
-          <annotation>
-            <documentation>Using Layout for @message, when publish the message as a JSON structure. If false then the defined layout will not be used.</documentation>
-          </annotation>
-        </attribute>
+				<attribute name="useLayoutAsMessage" type="boolean" default="false">
+					<annotation>
+						<documentation>Using Layout for @message, when publish the message as a JSON structure. If false then the defined layout will not be used.</documentation>
+					</annotation>
+				</attribute>
 				<attribute name="compression" type="string" default="none">
 					<annotation>
 						<documentation>Compression type: none, gzip</documentation>
 					</annotation>
-				</attribute>				 
+				</attribute>
 			</extension>
 		</complexContent>
 	</complexType>

--- a/src/schemas/NLog.RabbitMQ.xsd
+++ b/src/schemas/NLog.RabbitMQ.xsd
@@ -31,6 +31,7 @@
 					<element name="maxBuffer" type="integer" minOccurs="0" maxOccurs="1" />
 					<element name="heartBeatSeconds" type="unsignedShort" minOccurs="0" maxOccurs="1" />
 					<element name="useJSON" type="boolean" minOccurs="0" maxOccurs="1" />
+          <element name="useLayoutAsMessage" type="boolean" minOccurs="0" maxOccurs="1" />
 					<element name="compression" type="string" minOccurs="0" maxOccurs="1" />
 					<element name="layout" type="nlog:Layout" minOccurs="0" maxOccurs="1" />
 					<element name="field" minOccurs="0" maxOccurs="unbounded">
@@ -105,11 +106,16 @@
 						<documentation>The number seconds to wait between heartbeats.</documentation>
 					</annotation>
 				</attribute>
-				 <attribute name="useJSON" type="boolean" default="false">
-					 <annotation>
-						 <documentation>Whether to publish the message as a JSON structure (recommended!). If true then the defined layout will not be used.</documentation>
-					 </annotation>
-				 </attribute>
+				<attribute name="useJSON" type="boolean" default="false">
+				 <annotation>
+					 <documentation>Whether to publish the message as a JSON structure (recommended!). If true then the defined layout will not be used.</documentation>
+				 </annotation>
+				</attribute>
+        <attribute name="useLayoutAsMessage" type="boolean" default="false">
+          <annotation>
+            <documentation>Using Layout for @message, when publish the message as a JSON structure. If false then the defined layout will not be used.</documentation>
+          </annotation>
+        </attribute>
 				<attribute name="compression" type="string" default="none">
 					<annotation>
 						<documentation>Compression type: none, gzip</documentation>


### PR DESCRIPTION
I added UseLayoutAsMessage property for allow using Layout property as Message in JSON format (#24). 

By default, property set as false for keeping current logic.

Why we are planing use this? We have some additional extensions for NLog (for example, card number masking) what using for replace standard ${message} in our logs, and we want using them with this extensions also.