### PR TITLE
Hack for compatibility RabbitMQ.Client library between 3.4.x and 3.5.…

### DIFF
--- a/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
+++ b/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
@@ -338,8 +338,9 @@ namespace NLog.Targets
 				//InternalLogger.Error("Could not write data to the network stream! {0}", e.ToString());
 			}
 
-			ShutdownAmqp(_Connection, new ShutdownEventArgs(ShutdownInitiator.Application,
-															Constants.ChannelError, "Could not talk to RabbitMQ instance", null));
+			ShutdownAmqp(_Connection, 
+				new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ChannelError, "Could not talk to RabbitMQ instance", null));
+				// using this version of constructor, because RabbitMQ.Client from 3.5.x don't have ctor without cause parameter
 		}
 
 		private void AddUnsent(string routingKey, IBasicProperties basicProperties, byte[] message)
@@ -554,6 +555,7 @@ namespace NLog.Targets
 		{
 			ShutdownAmqp(_Connection,
 						 new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess, "closing appender", null));
+						// using this version of constructor, because RabbitMQ.Client from 3.5.x don't have ctor without cause parameter
 			
 			base.CloseTarget();
 		}

--- a/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
+++ b/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
@@ -312,7 +312,7 @@ namespace NLog.Targets
 
 			if (_Model == null || !_Model.IsOpen)
 				StartConnection();
-			
+
 			if (_Model == null || !_Model.IsOpen)
 			{
 				AddUnsent(routingKey, basicProperties, message);

--- a/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
+++ b/src/NLog.Targets.RabbitMQ/RabbitMQ.cs
@@ -310,7 +310,7 @@ namespace NLog.Targets
 
 			if (_Model == null || !_Model.IsOpen)
 				StartConnection();
-
+			
 			if (_Model == null || !_Model.IsOpen)
 			{
 				AddUnsent(routingKey, basicProperties, message);
@@ -337,7 +337,7 @@ namespace NLog.Targets
 			}
 
 			ShutdownAmqp(_Connection, new ShutdownEventArgs(ShutdownInitiator.Application,
-															Constants.ChannelError, "Could not talk to RabbitMQ instance"));
+															Constants.ChannelError, "Could not talk to RabbitMQ instance", null));
 		}
 
 		private void AddUnsent(string routingKey, IBasicProperties basicProperties, byte[] message)
@@ -536,7 +536,7 @@ namespace NLog.Targets
 		protected override void CloseTarget()
 		{
 			ShutdownAmqp(_Connection,
-						 new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess, "closing appender"));
+						 new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess, "closing appender", null));
 			
 			base.CloseTarget();
 		}


### PR DESCRIPTION
I wrote add delegate for ConnectionShutdown event using reflection.
This allow using both version of RabbitMQ.Client library 3.4.x and 3.5.x

I don't know how much is a good solution...

issue #22